### PR TITLE
added respawn script to the install location 

### DIFF
--- a/node_manager_fkie/CMakeLists.txt
+++ b/node_manager_fkie/CMakeLists.txt
@@ -9,6 +9,7 @@ install(
     PROGRAMS 
         nodes/node_manager
         scripts/remote_nm.py
+        scripts/respawn
     DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
     )
 


### PR DESCRIPTION
nodes with the respawn attribute set to true will silently just not start since respawn is not found by rosrun :(
