### PR TITLE
Configuration option to ignore only topic publisher or subscribers

### DIFF
--- a/master_discovery_fkie/src/master_discovery_fkie/filter_interface.py
+++ b/master_discovery_fkie/src/master_discovery_fkie/filter_interface.py
@@ -54,6 +54,7 @@ class FilterInterface(object):
   def load(self, mastername='',
            ignore_nodes=[], sync_nodes=[],
            ignore_topics=[], sync_topics=[],
+           ignore_subscribers=[], ignore_publishers=[],
            ignore_srv=[], sync_srv=[],
            ignore_type=[]):
     '''
@@ -69,6 +70,10 @@ class FilterInterface(object):
                                          sync_nodes, mastername)
     self._re_ignore_topics = create_pattern('ignore_topics', data, interface_file,
                                             ignore_topics, mastername)
+    self._re_ignore_publishers = create_pattern('ignore_publishers', data, interface_file,
+                                            ignore_publishers, mastername)
+    self._re_ignore_subscribers = create_pattern('ignore_subscribers', data, interface_file,
+                                            ignore_subscribers, mastername)
     self._re_sync_topics = create_pattern('sync_topics', data, interface_file, 
                                           sync_topics, mastername)
     self._re_ignore_services = create_pattern('ignore_services', data, interface_file, 
@@ -166,6 +171,12 @@ class FilterInterface(object):
     # there are no sync nodes and topic lists defined => return False (=>sync the given topic)
     return not is_empty_pattern(self._re_sync_nodes) or not is_empty_pattern(self._re_sync_topics)
 
+  def is_ignored_subscriber(self, node, topic, topictype):
+    return self._re_ignore_subscribers.match(topic) or self.is_ignored_topic(node, topic, topictype)
+
+  def is_ignored_publisher(self, node, topic, topictype):
+    return self._re_ignore_publishers.match(topic) or self.is_ignored_topic(node, topic, topictype)
+
   def is_ignored_service(self, node, service):
     '''
     Searches firstly in ignore lists `ignore_nodes` and `ignore_services`. 
@@ -216,6 +227,8 @@ class FilterInterface(object):
             _to_str(self._re_sync_nodes),
             _to_str(self._re_ignore_topics),
             _to_str(self._re_sync_topics),
+            _to_str(self._re_ignore_publishers),
+            _to_str(self._re_ignore_subscribers),
             _to_str(self._re_ignore_services),
             _to_str(self._re_sync_services),
             _to_str(self._re_ignore_type))
@@ -246,9 +259,11 @@ class FilterInterface(object):
       result._re_sync_nodes = _from_str(l[2])
       result._re_ignore_topics = _from_str(l[3])
       result._re_sync_topics = _from_str(l[4])
-      result._re_ignore_services = _from_str(l[5])
-      result._re_sync_services = _from_str(l[6])
-      result._re_ignore_type = _from_str(l[7])
+      result._re_ignore_publishers = _from_str(l[5])
+      result._re_ignore_subscribers = _from_str(l[6])
+      result._re_ignore_services = _from_str(l[7])
+      result._re_sync_services = _from_str(l[8])
+      result._re_ignore_type = _from_str(l[9])
       result.is_valid = True
       return result
     except:

--- a/master_discovery_fkie/src/master_discovery_fkie/master_info.py
+++ b/master_discovery_fkie/src/master_discovery_fkie/master_info.py
@@ -1136,7 +1136,7 @@ class MasterInfo(object):
       pn = []
       for n in topic.publisherNodes:
         if n in added_nodes:
-          if not iffilter.is_ignored_topic(n, name, topic.type):
+          if not iffilter.is_ignored_publisher(n, name, topic.type):
             pn.append(n)
             nodes_last_check.add(n)
       if pn:
@@ -1144,7 +1144,7 @@ class MasterInfo(object):
       sn = []
       for n in topic.subscriberNodes:
         if n in added_nodes:
-          if not iffilter.is_ignored_topic(n, name, topic.type):
+          if not iffilter.is_ignored_subscriber(n, name, topic.type):
             sn.append(n)
             nodes_last_check.add(n)
       if sn:

--- a/master_sync_fkie/src/master_sync_fkie/sync_thread.py
+++ b/master_sync_fkie/src/master_sync_fkie/sync_thread.py
@@ -103,10 +103,10 @@ class SyncThread(object):
     self._filter.load(self.name,
                       ['/rosout', rospy.get_name().replace('/', '/*')+'*', self.discoverer_name.replace('/', '/*')+'*', '/*node_manager', '/*zeroconf'], [],
                       ['/rosout', '/rosout_agg'], ['/'] if sync_on_demand else [],
-                      [], [],
                       ['/*get_loggers', '/*set_logger_level'], [],
                       # do not sync the bond message of the nodelets!!
-                      ['bond/Status'])
+                      ['bond/Status'],
+                      [], [])
 
     # congestion avoidance: wait for random.random*2 sec. If an update request 
     # is received try to cancel and restart the current timer. The timer can be

--- a/master_sync_fkie/src/master_sync_fkie/sync_thread.py
+++ b/master_sync_fkie/src/master_sync_fkie/sync_thread.py
@@ -103,6 +103,7 @@ class SyncThread(object):
     self._filter.load(self.name,
                       ['/rosout', rospy.get_name().replace('/', '/*')+'*', self.discoverer_name.replace('/', '/*')+'*', '/*node_manager', '/*zeroconf'], [],
                       ['/rosout', '/rosout_agg'], ['/'] if sync_on_demand else [],
+                      [], [],
                       ['/*get_loggers', '/*set_logger_level'], [],
                       # do not sync the bond message of the nodelets!!
                       ['bond/Status'])
@@ -266,7 +267,7 @@ class SyncThread(object):
         for node in nodes:
           topictype = self._getTopicType(topic, topicTypes)
           nodeuri = self._getNodeUri(node, nodeProviders, remote_masteruri)
-          if topictype and nodeuri and not self._doIgnoreNT(node, topic, topictype):
+          if topictype and nodeuri and not self._doIgnoreNTP(node, topic, topictype):
             # register the nodes only once
             if not ((topic, node, nodeuri) in self.__publisher):
               publisher_to_register.append((topic, topictype, node, nodeuri))
@@ -293,7 +294,7 @@ class SyncThread(object):
 #              topictype = self.__own_state.topics[topic].type
           if not topictype:
             topictype = self.MSG_ANY_TYPE
-          if topictype and nodeuri and not self._doIgnoreNT(node, topic, topictype):
+          if topictype and nodeuri and not self._doIgnoreNTS(node, topic, topictype):
             # register the node as subscriber in local ROS master
             if not ((topic, node, nodeuri) in self.__subscriber):
               subscriber_to_register.append((topic, topictype, node, nodeuri))
@@ -425,8 +426,11 @@ class SyncThread(object):
         rospy.logwarn("SyncThread[%s] ERROR while ending: %s", self.name, traceback.format_exc())
       socket.setdefaulttimeout(None)
 
-  def _doIgnoreNT(self, node, topic, topictype):
-    return self._filter.is_ignored_topic(node, topic, topictype)
+  def _doIgnoreNTP(self, node, topic, topictype):
+    return self._filter.is_ignored_publisher(node, topic, topictype)
+
+  def _doIgnoreNTS(self, node, topic, topictype):
+    return self._filter.is_ignored_subscriber(node, topic, topictype)
 
   def _doIgnoreNS(self, node, service):
     return self._filter.is_ignored_service(node, service)


### PR DESCRIPTION
This is mostly a request for review to the approach in general. Would be happy to hear if this type of addition is palatable or if a different approach is recommended.

This PR adds two new configuration parameters: ignore_publishers and ignore_subscribers. If either of those are set, then subscribers or publishers in particular for the listed topics will be ignored.

We needed this enhancement for a particular set-up in which we need to avoid propagating subscribers of a particular topic (/clock) while at the same time allowing the propagation of publishers of this same topic.