### PR TITLE
Bind to non default interface

### DIFF
--- a/master_discovery_fkie/CMakeLists.txt
+++ b/master_discovery_fkie/CMakeLists.txt
@@ -8,8 +8,14 @@ catkin_python_setup()
 catkin_package(CATKIN_DEPENDS multimaster_msgs_fkie)
 
 install(
-    PROGRAMS 
+    PROGRAMS
         nodes/master_discovery
         nodes/zeroconf
     DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
-    )
+)
+
+install(
+    DIRECTORY
+    launch
+    DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
+)

--- a/master_discovery_fkie/launch/master_discovery.launch
+++ b/master_discovery_fkie/launch/master_discovery.launch
@@ -1,3 +1,4 @@
+<?xml version="1.0"?>
 <launch>
   <node name="master_discovery" pkg="master_discovery_fkie" type="master_discovery">
     <param name="log_level" value="INFO" />
@@ -10,7 +11,7 @@
     <!-- the send rate of the heartbeat packets in hz. Zero disables the heartbeats. (Default: 0.02 Hz)
       Only values between 0.1 and 25.5 are used to detemine the link quality. -->
     <param name="heartbeat_hz" value="0.02" />
-    <!-- the count of intervals (1 sec) used for a quality calculation. If 
+    <!-- the count of intervals (1 sec) used for a quality calculation. If
       `HEARTBEAT_HZ` is smaller then 1, `MEASUREMENT_INTERVALS` will be divided
       by `HEARTBEAT_HZ` value.
       (Default: 5 sec are used to determine the link qaulity) -->
@@ -21,11 +22,11 @@
     <param name="remove_after" value="300" />
     <!-- send an update request, if after this time no hearbeats are received [sec] (Default: 60 sec). -->
     <param name="active_request_after" value="60" />
-    <!-- in some network environments does multicast not work properly. In this 
-      case you can specify robots where a master discovery is running. These 
+    <!-- in some network environments does multicast not work properly. In this
+      case you can specify robots where a master discovery is running. These
       robots are pinged using unicast communication. -->
     <rosparam param="robot_hosts">[]</rosparam>
-    <!-- After the ROS master was changed the new state will be sent for 
+    <!-- After the ROS master was changed the new state will be sent for
       `CHANGE_NOTIFICATION_COUNT` times (Default: 3 sec). The new state will be
       sent with `ROSMASTER_HZ` and only if `HEARTBEAT_HZ` is zero. -->
     <param name="change_notification_count" value="3" />

--- a/master_discovery_fkie/src/master_discovery_fkie/master_discovery.py
+++ b/master_discovery_fkie/src/master_discovery_fkie/master_discovery.py
@@ -30,6 +30,7 @@
 # ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
+import os
 import threading
 import xmlrpclib
 import sys
@@ -50,13 +51,13 @@ try: # to avoid the problems with autodoc on ros.org/wiki site
 except:
   pass
 from master_discovery_fkie.master_monitor import MasterMonitor, MasterConnectionException
-from master_discovery_fkie.udp import McastSocket
+from master_discovery_fkie.udp import McastSocket, UcastSocket
 
 class DiscoveredMaster(object):
   '''
   The class stores all information about the remote ROS master and the all
-  received heartbeat messages of the remote node. On first contact a theaded 
-  connection to remote discoverer will be established to get additional 
+  received heartbeat messages of the remote node. On first contact a theaded
+  connection to remote discoverer will be established to get additional
   information about the ROS master.
 
   :param monitoruri: The URI of the remote RPC server, which moniter the ROS master
@@ -95,10 +96,6 @@ class DiscoveredMaster(object):
 
     :type monitoruri:  str
 
-    :param is_local: is the URI of the remote RPC server local or not
-
-    :type is_local:  bool
-
     :param heartbeat_rate: The remote rate, which is used to send the heartbeat messages.
 
     :type heartbeat_rate:  float (Default: `1.``)
@@ -136,7 +133,7 @@ class DiscoveredMaster(object):
     self._errors = dict() #ERR_*, msg
     self.masteruriaddr = None
     # create a thread to retrieve additional information about the remote ROS master
-    self._retrieveThread = threading.Thread(target = self.__retrieve_masterinfo)
+    self._retrieveThread = threading.Thread(target=self.__retrieve_masterinfo)
     self._retrieveThread.setDaemon(True)
     self._retrieveThread.start()
 
@@ -495,7 +492,7 @@ class Discoverer(object):
     self._send_mcast = rospy.get_param('~send_mcast', True)
     # for cases with more then one master_discovery on the same host and
     # heartbeat rate is less then 0.1. In this case we have to send a multicast
-    # request reply, because we are bind to the same port. Unicast replies are 
+    # request reply, because we are bind to the same port. Unicast replies are
     # not forward to the same port only once.
     self._addresses = dict() # {address : (int) ocurres}
 
@@ -524,12 +521,26 @@ class Discoverer(object):
     # test the reachability of the ROS master
     local_addr = roslib.network.get_local_address()
     if (local_addr in ['localhost', '127.0.0.1']):
-      sys.exit("'%s' is not reachable for other systems. Change the ROS_MASTER_URI!"% local_addr)
+      rospy.logwarn("'%s' is not reachable for other systems. Change the ROS_MASTER_URI!" % local_addr)
+
+
+    # Get the interface to bind to for mcast discovery and xml-rpc.
+    # Use the ~interface param unless ROS_IP is set, use that explicitly
+    # otherwise.
+    self.interface = rospy.get_param('~interface', '')
+    if not self.interface and 'ROS_IP' in os.environ:
+      self.interface = os.environ['ROS_IP']
+      rospy.loginfo("Using user set ROS_IP for interface: %s", self.interface)
+    # Log what interface we're binding to.
+    if self.interface == "":
+      rospy.loginfo("Interface to bind: Default interface")
+    else:
+      rospy.loginfo("Interface to bind: %s", self.interface)
 
     self.mcast_port = mcast_port
     self.mcast_group = mcast_group
     rospy.loginfo("Start broadcasting at ('%s', %d)", mcast_group, mcast_port)
-    self._init_mcast_socket(True)
+    self._init_sockets(True)
     # initialize the ROS publishers
     self.pubchanges = rospy.Publisher("~changes", MasterState, queue_size=10)
     # initialize the ROS services
@@ -544,9 +555,14 @@ class Discoverer(object):
     self._timer_ros_changes = threading.Timer(0.1, self.checkROSMaster_loop)
 
     # create a thread to handle the received multicast messages
-    self._recv_thread = threading.Thread(target = self.recv_loop)
-    self._recv_thread.setDaemon(True)
-    self._recv_thread.start()
+    self._recvThread = threading.Thread(target=self.multicast_recv_loop)
+    self._recvThread.setDaemon(True)
+    self._recvThread.start()
+
+    # create a thread to handle the received unicast messages
+    self._recvThread = threading.Thread(target=self.unicast_recv_loop)
+    self._recvThread.setDaemon(True)
+    self._recvThread.start()
 
     # create a timer monitor the offline ROS master and calculate the link qualities
     self._timer_stats = threading.Timer(1, self.timed_stats_calculation)
@@ -573,13 +589,17 @@ class Discoverer(object):
       pass
     return False
 
-  def _init_mcast_socket(self, doexit_on_error=False):
+  def _init_sockets(self, doexit_on_error=False):
     rospy.loginfo("Init multicast socket")
     # create the multicast socket and join the multicast group
-    self.msocket = msocket = McastSocket(self.mcast_port, self.mcast_group)
+    self.msocket = msocket = McastSocket(self.interface, self.mcast_port, self.mcast_group)
 #    msocket.settimeout(3.0)
     if not msocket.hasEnabledMulticastIface() and doexit_on_error:
       sys.exit("No enabled multicast interfaces available!\nAdd multicast support e.g. sudo ifconfig eth0 multicast")
+
+    rospy.loginfo("Init unicast socket")
+    # create the multicast socket and join the multicast group
+    self.usocket = UcastSocket(self.interface, self.mcast_port)
 
   def finish(self, *arg):
     '''
@@ -621,7 +641,7 @@ class Discoverer(object):
     self.msocket.send2group(msg)
     # send as unicast
     for remote_master in self.robots:
-      self.msocket.send2addr(msg, remote_master)
+      self.usocket.send2addr(msg, remote_master)
     time.sleep(0.2)
     self.msocket.close()
 
@@ -651,7 +671,7 @@ class Discoverer(object):
             self._send_request2addr(remote_master)
         except Exception as err:
           rospy.logwarn(err)
-          self._init_mcast_socket()
+          self._init_sockets()
       if not self.do_finish and (self.HEARTBEAT_HZ > 0. or self._init_notifications < self.INIT_NOTIFICATION_COUNT):
         sleeptime = 1.0/self.HEARTBEAT_HZ if self.HEARTBEAT_HZ > 0. else 1.0
         self._timer_heartbeat = threading.Timer(sleeptime, self.send_heardbeat)
@@ -667,10 +687,10 @@ class Discoverer(object):
         else:
           # to receive own messages, send to localhost
           rospy.logdebug('Send current state only to localhost:%s'%(self.mcast_port))
-          self.msocket.send2addr(msg, 'localhost')
+          self.usocket.send2addr(msg, 'localhost')
     except Exception as e:
       rospy.logwarn('Send current state to mcast group %s:%s failed: %s\n'%(self.mcast_group, self.mcast_port, e))
-      self._init_mcast_socket()
+      self._init_sockets()
 
   def _send_current_state2addr(self, address):
     try:
@@ -678,12 +698,12 @@ class Discoverer(object):
       if not msg is None:
         if self._send_mcast:
           rospy.logdebug('Send current state to addr %s'%(address))
-          self.msocket.send2addr(msg, address)
+          self.usocket.send2addr(msg, address)
           if self._is_multi_address(address):
             self._send_current_state2group()
     except Exception as e:
       rospy.logwarn("Send current state to '%s' failed: %s"%(address, e))
-      self._init_mcast_socket()
+      self._init_sockets()
 
   def _send_request2group(self):
     try:
@@ -698,7 +718,7 @@ class Discoverer(object):
   def _send_request2addr(self, address, master=None):
     try:
       rospy.logdebug('Send a request for update: %s'%address)
-      self.msocket.send2addr(self._create_request_update_msg(), address)
+      self.usocket.send2addr(self._create_request_update_msg(), address)
       if self._is_multi_address(address):
         self._send_request2group()
       if not master is None:
@@ -798,7 +818,7 @@ class Discoverer(object):
         del self.masters[r]
 
 
-  def recv_loop(self):
+  def multicast_recv_loop(self):
     '''
     This method handles the received multicast messages.
     '''
@@ -806,69 +826,95 @@ class Discoverer(object):
       try:
         (msg, address) = self.msocket.recvfrom(1024)
       except socket.timeout:
-#        rospy.logwarn("TIMOUT ignored")
+        rospy.logwarn("TIMOUT ignored")
         pass
       except socket.error:
         import traceback
         rospy.logwarn("socket error: %s", traceback.format_exc())
       else:
-        if not self.do_finish:
-          try:
-            (version, msg_tuple) = self.msg2masterState(msg, address)
-            if (version in [2, 3]):
-              add_to_list = False
-              (r, version, rate, secs, nsecs, monitor_port, secs_l, nsecs_l) = msg_tuple
-              master_key = (address, monitor_port)
-              # is it a request to update the state
-              if version >= 3 and secs == 0 and nsecs == 0:
-                # send the current master state to the sender address
-                # if send_mcast is disabled responce only to local requests
-                if (self._send_mcast or address[0].startswith('127')):
-                  with self.__lock:
-                    self._send_current_state2addr(address[0])
-                    add_to_list = not master_key in self.masters
-              # remove master if sec and nsec are -1
-              elif secs == -1 or secs_l == -1:
-                with self.__lock:
-                  if self.masters.has_key(master_key):
-                    master = self.masters[master_key]
-                    if not master.mastername is None:
-                      self.publish_masterstate(MasterState(MasterState.STATE_REMOVED,
-                                                     ROSMaster(str(master.mastername),
-                                                               master.masteruri,
-                                                               master.timestamp,
-                                                               master.timestamp_local,
-                                                               False,
-                                                               master.discoverername,
-                                                               master.monitoruri)))
-                    rospy.loginfo("Remove master discovery: http://%s:%s, with ROS_MASTER_URI=%s"%(address[0], monitor_port, master.masteruri))
-                    self._rem_address(address[0])
-                    del self.masters[master_key]
-              # update the timestamp of existing master
-              elif self.masters.has_key(master_key):
-                with self.__lock:
-                  changed = self.masters[master_key].add_heartbeat(float(secs)+float(nsecs)/1000000000.0, float(secs_l)+float(nsecs_l)/1000000000.0, float(rate)/10.0,)
-                  if not self._changed:
-                    self._changed = changed
-              # or create <a new master
-              else:
-                add_to_list = True
-              if add_to_list:
-                with self.__lock:
-                  rospy.loginfo("Detected master discovery: http://%s:%s"%(address[0], monitor_port))
-                  self._add_address(address[0])
-                  is_local = address[0].startswith('127.') or address[0] in roslib.network.get_local_addresses()
-                  self.masters[master_key] = DiscoveredMaster(monitoruri=''.join(['http://', address[0],':',str(monitor_port)]),
-                                                              is_local=is_local,
-                                                              heartbeat_rate=float(rate)/10.0,
-                                                              timestamp=float(secs)+float(nsecs)/1000000000.0,
-                                                              timestamp_local=float(secs_l)+float(nsecs_l)/1000000000.0,
-                                                              callback_master_state=self.publish_masterstate)
+        self.process_recv_message(msg, address)
 
-          except Exception, e:
-#            import traceback
-#            print traceback.format_exc()
-            rospy.logwarn("Error while decode message: %s", str(e))
+  def unicast_recv_loop(self):
+    '''
+    This method handles the received unicast messages.
+    '''
+    while self.msocket and (not rospy.is_shutdown()) and not self.do_finish:
+      try:
+        (msg, address) = self.usocket.recvfrom(1024)
+      except socket.timeout:
+        rospy.logwarn("TIMOUT ignored")
+        pass
+      except socket.error:
+        import traceback
+        rospy.logwarn("socket error: %s", traceback.format_exc())
+      else:
+        self.process_recv_message(msg, address)
+
+
+  def process_recv_message(self, msg, address):
+    """
+    Process the received message from either the unicast or multicast receive
+    paths.
+
+    :param msg: The message received
+    :param address: The address the message was received from.
+    """
+    if not self.do_finish:
+      try:
+        (version, msg_tuple) = self.msg2masterState(msg, address)
+        if (version in [2, 3]):
+          add_to_list = False
+          (r, version, rate, secs, nsecs, monitor_port, secs_l, nsecs_l) = msg_tuple
+          master_key = (address, monitor_port)
+          # is it a request to update the state
+          if version >= 3 and secs == 0 and nsecs == 0:
+            # send the current master state to the sender address
+            # if send_mcast is disabled responce only to local requests
+            if (self._send_mcast or address[0].startswith('127')):
+              with self.__lock:
+                self._send_current_state2addr(address[0])
+                add_to_list = not master_key in self.masters
+          # remove master if sec and nsec are -1
+          elif secs == -1 or secs_l == -1:
+            with self.__lock:
+              if self.masters.has_key(master_key):
+                master = self.masters[master_key]
+                if not master.mastername is None:
+                  self.publish_masterstate(MasterState(MasterState.STATE_REMOVED,
+                                                  ROSMaster(str(master.mastername),
+                                                            master.masteruri,
+                                                            master.timestamp,
+                                                            master.timestamp_local,
+                                                            False,
+                                                            master.discoverername,
+                                                            master.monitoruri)))
+                rospy.loginfo("Remove master discovery: http://%s:%s, with ROS_MASTER_URI=%s"
+                              %(address[0], monitor_port, master.masteruri))
+                self._rem_address(address[0])
+                del self.masters[master_key]
+          # update the timestamp of existing master
+          elif self.masters.has_key(master_key):
+            with self.__lock:
+              changed = self.masters[master_key].add_heartbeat(float(secs)+float(nsecs)/1000000000.0,
+                                                                float(secs_l)+float(nsecs_l)/1000000000.0,
+                                                                float(rate)/10.0,)
+              if not self._changed:
+                self._changed = changed
+          # or create <a new master
+          else:
+            add_to_list = True
+          if add_to_list:
+            with self.__lock:
+              rospy.loginfo("Detected master discovery: http://%s:%s"%(address[0], monitor_port))
+              self._add_address(address[0])
+              self.masters[master_key] = DiscoveredMaster(monitoruri=''.join(['http://', address[0],':',str(monitor_port)]),
+                                                          heartbeat_rate=float(rate)/10.0,
+                                                          timestamp=float(secs)+float(nsecs)/1000000000.0,
+                                                          timestamp_local=float(secs_l)+float(nsecs_l)/1000000000.0,
+                                                          callback_master_state=self.publish_masterstate)
+
+      except Exception, e:
+        rospy.logwarn("Error while decode message: %s", str(e))
 
   def _is_multi_address(self, address):
     return address in self._addresses and self._addresses[address] > 1

--- a/master_discovery_fkie/src/master_discovery_fkie/master_info.py
+++ b/master_discovery_fkie/src/master_discovery_fkie/master_info.py
@@ -40,27 +40,27 @@ class NodeInfo(object):
   The NodeInfo class stores informations about a ROS node.
 
   :param name: the name of the node
-  
+
   :type name: str
-  
-  :param masteruri: the URI of the ROS master, where the node is registered. 
-                    This masteruri will be used to determine, whether the ROS master and the 
+
+  :param masteruri: the URI of the ROS master, where the node is registered.
+                    This masteruri will be used to determine, whether the ROS master and the
                     node are running on the same machine.
-  
+
   :type masteruri: str
   '''
   def __init__(self, name, masteruri):
     '''
     Creates a new NodeInfo for a node with given name.
-    
+
     :param name: the name of the node
-    
+
     :type name: str
-    
-    :param masteruri: the URI of the ROS master, where the node is registered. 
-                      This masteruri will be used to determine, whether the ROS master and the 
+
+    :param masteruri: the URI of the ROS master, where the node is registered.
+                      This masteruri will be used to determine, whether the ROS master and the
                       node are running on the same machine.
-    
+
     :type masteruri: str
     '''
     self.__name = name
@@ -79,7 +79,7 @@ class NodeInfo(object):
   def name(self):
     '''
     :return: the name of the node.
-    
+
     :rtype: str
     '''
     return self.__name
@@ -88,7 +88,7 @@ class NodeInfo(object):
   def uri(self):
     '''
     :return: the URI of the RPC API of the node.
-    
+
     :rtype: str
     '''
     return self.__uri
@@ -105,7 +105,7 @@ class NodeInfo(object):
   def masteruri(self):
     '''
     :return: the URI of the ROS master where the node is registered.
-    
+
     :rtype: str
     '''
     return self.__org_masteruri
@@ -123,7 +123,7 @@ class NodeInfo(object):
   def isLocal(self):
     '''
     :return: ``True`` if the node and the ROS master are running on the same machine.
-    
+
     :rtype: bool
     '''
     return self.__local
@@ -141,19 +141,19 @@ class NodeInfo(object):
   def publishedTopics(self):
     '''
     :return: the list of all published topics by this node.
-    
+
     :rtype: list of strings
     '''
     return self._publishedTopics
-  
+
   @publishedTopics.setter
   def publishedTopics(self, name):
     '''
     Append a new published topic to this node.
-    
+
     :param name: the name of the topic
-    
-    :type name: str 
+
+    :type name: str
     '''
     try:
       if isinstance(name, list):
@@ -172,19 +172,19 @@ class NodeInfo(object):
   def subscribedTopics(self):
     '''
     :return: the list of all subscribed topics by this node.
-    
+
     :rtype: list of strings
     '''
     return self._subscribedTopics
-  
+
   @subscribedTopics.setter
   def subscribedTopics(self, name):
     '''
     Append a new subscribed topic to this node.
-    
+
     :param name: the name of the topic
-    
-    :type name: str 
+
+    :type name: str
     '''
     try:
       if isinstance(name, list):
@@ -203,19 +203,19 @@ class NodeInfo(object):
   def services(self):
     '''
     :return: the list of all services provided by this node.
-    
+
     :rtype: list of strings
     '''
     return self._services
-  
+
   @services.setter
   def services(self, name):
     '''
     Append a new service to this node.
-    
+
     :param name: the name of the topic
-    
-    :type name: str 
+
+    :type name: str
     '''
     try:
       if isinstance(name, list):
@@ -229,13 +229,13 @@ class NodeInfo(object):
 #  @services.deleter
 #  def services(self):
 #    del self._services
-  
+
   def copy(self, new_masteruri=None):
     '''
     Creates a copy of this object and returns it.
-    
+
     :param new_masteruri: the masteruri of the new masterinfo
-    :rtype: :mod:`master_discovery_fkie.master_info.NodeInfo` 
+    :rtype: :mod:`master_discovery_fkie.master_info.NodeInfo`
     '''
     if new_masteruri is None:
       new_masteruri = self.masteruri
@@ -252,7 +252,7 @@ class NodeInfo(object):
   def local_(masteruri, org_masteruri, uri):
     '''
     Test the node whether it's run on the same machineas the ROS master and ``masteruri`` and ``org_masteruri`` are equal.
-    
+
     :param masteruri: The URI of the ROS master currently tested.
 
     :type masteruri: str
@@ -283,16 +283,16 @@ class TopicInfo(object):
   The TopicInfo class stores informations about a ROS topic.
 
   :param name: the name of the topic
-  
-  :type name: str 
+
+  :type name: str
   '''
   def __init__(self, name):
     '''
     Creates a new TopicInfo for a topic with given name.
-    
+
     :param name: the name of the topic
-    
-    :type name: str 
+
+    :type name: str
     '''
     self.__name = name
     self.type = None
@@ -304,7 +304,7 @@ class TopicInfo(object):
   def name(self):
     '''
     :return: the name of the topic.
-    
+
     :rtype: str
     '''
     return self.__name
@@ -313,11 +313,11 @@ class TopicInfo(object):
   def publisherNodes(self):
     '''
     :return: the list with node names witch are publishing to this topic.
-    
+
     :rtype: list of strings
     '''
     return list(self._publisherNodes)
-  
+
   @publisherNodes.setter
   def publisherNodes(self, name):
     '''
@@ -340,11 +340,11 @@ class TopicInfo(object):
   def subscriberNodes(self):
     '''
     :return: the list with node names witch are subscribed to this topic.
-    
+
     :rtype: list of strings
     '''
     return list(self._subscriberNodes)
-  
+
   @subscriberNodes.setter
   def subscriberNodes(self, name):
     '''
@@ -366,8 +366,8 @@ class TopicInfo(object):
   def copy(self):
     '''
     Creates a copy this object and returns it.
-    
-    :rtype: :mod:`master_discovery_fkie.master_info.TopicInfo` 
+
+    :rtype: :mod:`master_discovery_fkie.master_info.TopicInfo`
     '''
     result = TopicInfo(self.name)
     result.type = self.type
@@ -381,27 +381,27 @@ class ServiceInfo(object):
   The ServiceInfo class stores informations about a ROS service.
 
   :param name: the name of the service
-  
+
   :type name: str
-  
-  :param masteruri: the URI of the ROS master, where the service is registered. 
-                    This masteruri will be used to determine, whether the ROS master and the 
+
+  :param masteruri: the URI of the ROS master, where the service is registered.
+                    This masteruri will be used to determine, whether the ROS master and the
                     service are running on the same machine.
-  
+
   :type masteruri: str
   '''
   def __init__(self, name, masteruri):
     '''
-    Creates a new instance of the ServiceInfo. 
-    
+    Creates a new instance of the ServiceInfo.
+
     :param name: the name of the service
-    
+
     :type name: str
-    
-    :param masteruri: the URI of the ROS master, where the service is registered. 
-                      This masteruri will be used to determine, whether the ROS master and the 
+
+    :param masteruri: the URI of the ROS master, where the service is registered.
+                      This masteruri will be used to determine, whether the ROS master and the
                       service are running on the same machine.
-    
+
     :type masteruri: str
     '''
     self.__name = name
@@ -420,7 +420,7 @@ class ServiceInfo(object):
   def name(self):
     '''
     :return: the name of the service.
-    
+
     :rtype: str
     '''
     return self.__name
@@ -429,7 +429,7 @@ class ServiceInfo(object):
   def uri(self):
     '''
     :return: the URI of the RPC API of the service
-    
+
     :rtype: str
     '''
     return self.__uri
@@ -439,9 +439,9 @@ class ServiceInfo(object):
     '''
     Sets the uri of the service RPC interface and determine whether this service
     and the ROS master are running on the same machine.
-    
+
     :param uri: The URI of the service RPC interface
-    
+
     :type uri: str
     '''
     self.__uri = uri
@@ -451,19 +451,19 @@ class ServiceInfo(object):
   def masteruri(self):
     '''
     :return: the URI of the ROS master of the service
-    
+
     :rtype: str
     '''
     return self.__org_masteruri
-  
+
   @masteruri.setter
   def masteruri(self, uri):
     '''
     Sets the uri of the origin ROS master and determine whether this service
     and the ROS master are running on the same machine.
-    
+
     :param uri: The URI of the ROS master
-    
+
     :type uri: str
     '''
     self.__org_masteruri = uri
@@ -473,9 +473,9 @@ class ServiceInfo(object):
   @property
   def isLocal(self):
     '''
-    :return: ``True``, if this service and the master are on the same machine. 
+    :return: ``True``, if this service and the master are on the same machine.
              This will be determine on setting the uri-parameter.
-    
+
     :rtype: bool
     '''
     return self.__local
@@ -493,18 +493,18 @@ class ServiceInfo(object):
   def serviceProvider(self):
     '''
     :return: the list of the node names, which provide this service.
-    
+
     :rtype: list of strings
     '''
     return self._serviceProvider
-  
+
   @serviceProvider.setter
   def serviceProvider(self, name):
     '''
-    Adds a new service provider, if no one with given name exists. 
-    
+    Adds a new service provider, if no one with given name exists.
+
     :param name: name of the new service provider
-    
+
     :type name: str
     '''
     try:
@@ -521,15 +521,15 @@ class ServiceInfo(object):
     '''
     Get the service class using the type of the service. NOTE: this
     method is from `rosservice` and changed to avoid a probe call to the service.
-    
+
     :param allow_get_type: allow to connect to service and get the type if the type is not valid (in case of other host)
-    
+
     :type allow_get_type: bool
-    
+
     :return: service class
-    
+
     :rtype: ServiceDefinition: service class
-    
+
     :raise: ``ROSServiceException``, if service class cannot be retrieved
     '''
     if not self.__service_class is None:
@@ -576,7 +576,7 @@ class ServiceInfo(object):
             not hasattr(service_class, "_request_class"):
         srv_type = srv_type[:-7]
         service_class = roslib.message.get_service_class(srv_type)
-        
+
     if service_class is None:
         pkg = roslib.names.resource_name_package(self.type)
         raise rosservice.ROSServiceException("Unable to load type [%s].\n"%self.type+
@@ -587,9 +587,9 @@ class ServiceInfo(object):
   def copy(self, new_masteruri=None):
     '''
     Creates a copy of this object and returns it.
-    
+
     :param new_masteruri: the masteruri of the new masterinfo
-    :rtype: :mod:`master_discovery_fkie.master_info.NodeInfo` 
+    :rtype: :mod:`master_discovery_fkie.master_info.NodeInfo`
     '''
     if new_masteruri is None:
       new_masteruri = self.masteruri
@@ -608,26 +608,26 @@ class MasterInfo(object):
   Not thread safe!
 
   :param masteruri: The URI of the corresponding master
-  
+
   :type masteruri: str
-  
-  :param mastername: The name of the ROS master. If no one is given, it will be 
+
+  :param mastername: The name of the ROS master. If no one is given, it will be
                      extracted from the masteruri.
-  
+
   :type mastername: str or ``None`` (Default: ``None``)
   '''
   def __init__(self, masteruri, mastername = None):
     '''
-    Creates a new instance of the MasterInfo. The mastername will be extracted 
+    Creates a new instance of the MasterInfo. The mastername will be extracted
     from the masterui, if no name is given.
-    
+
     :param masteruri: The URI of the corresponding master
-    
+
     :type masteruri: str
-    
-    :param mastername: The name of the ROS master. If no one is given, it will be 
+
+    :param mastername: The name of the ROS master. If no one is given, it will be
                        extracted from the masteruri.
-    
+
     :type mastername: str or ``None`` (Default: ``None``)
     '''
     self.__masteruri = masteruri
@@ -648,13 +648,13 @@ class MasterInfo(object):
   def from_list(l):
     '''
     Creates a new instance of the MasterInfo from given list.
-    
+
     :param l: the list returned by :mod:`master_discovery_fkie.master_info.MasterInfo.listedState()`
-    
+
     :type l: list
-    
+
     :return: the new instance of the MasterInfo filled from list.
-    
+
     :rtype: :mod:`master_discovery_fkie.master_info.MasterInfo`
     '''
     if l is None:
@@ -712,7 +712,7 @@ class MasterInfo(object):
     '''
     :return: the name of the ROS master. In most cases the ROS master name is the
              name of the host, where the ROS master running. Although it can differ.
-    
+
     :rtype: str
     '''
     return self.__mastername
@@ -721,7 +721,7 @@ class MasterInfo(object):
   def masteruri(self):
     '''
     :return: the URI of the ROS master.
-    
+
     :rtype: str
     '''
     return self.__masteruri
@@ -729,10 +729,10 @@ class MasterInfo(object):
   @property
   def timestamp(self):
     '''
-    :return: The timestamp when this MasterInfo was first time filled with the 
+    :return: The timestamp when this MasterInfo was first time filled with the
              information. See :mod:`master_discovery_fkie.master_info.MasterInfo.check_ts()`
              to get the time, when the information was compared with the data of ROS Master.
-    
+
     :rtype: float
     '''
     return self.__timestamp
@@ -741,9 +741,9 @@ class MasterInfo(object):
   def timestamp(self, ts):
     '''
     Sets the timestamp of this instance
-    
+
     :param ts: the new timestamp
-    
+
     :type ts: float
     '''
     self.__timestamp = ts
@@ -753,12 +753,12 @@ class MasterInfo(object):
   @property
   def timestamp_local(self):
     '''
-    :return: The timestamp when this MasterInfo was first time filled with the 
+    :return: The timestamp when this MasterInfo was first time filled with the
              information. See :mod:`master_discovery_fkie.master_info.MasterInfo.check_ts()`
              to get the time, when the information was compared with the data of ROS Master.
              This timestamp is only updated, not synchronized nodes, topics or services are
              changed.
-    
+
     :rtype: float
     '''
     return self.__timestamp_local
@@ -767,9 +767,9 @@ class MasterInfo(object):
   def timestamp_local(self, ts):
     '''
     Sets the timestamp of this instance
-    
+
     :param ts: the new timestamp
-    
+
     :type ts: float
     '''
     self.__timestamp_local = ts
@@ -778,7 +778,7 @@ class MasterInfo(object):
   def nodes(self):
     '''
     :return: the dictionary with ``node names`` and corresponding instances of ``NodeInfo``.
-    
+
     :rtype: dict of (str : :mod:`master_discovery_fkie.master_info.NodeInfo`)
     '''
     return self.__nodelist
@@ -786,12 +786,12 @@ class MasterInfo(object):
   @nodes.setter
   def nodes(self, name):
     '''
-    Adds a new :mod:`master_discovery_fkie.master_info.NodeInfo` with given name. 
-    
+    Adds a new :mod:`master_discovery_fkie.master_info.NodeInfo` with given name.
+
     :note: If the NodeInfo already exists, do nothing.
-    
+
     :param name: the name of new :mod:`master_discovery_fkie.master_info.NodeInfo`
-    
+
     :type name: str
     '''
     if (name is None) or not name:
@@ -803,7 +803,7 @@ class MasterInfo(object):
   def node_names(self):
     '''
     :return: the list with node names
-    
+
     :rtype: list of strings
     '''
 #    @return: the list with node names
@@ -813,7 +813,7 @@ class MasterInfo(object):
   def node_uris(self):
     '''
     :return: the list with node URI's.
-    
+
     :rtype: list of strings
     '''
     uris = []
@@ -825,7 +825,7 @@ class MasterInfo(object):
   def topics(self):
     '''
     :return: the dictionary with ``topic names`` and corresponding ``TopicInfo`` instances.
-    
+
     :rtype: dict of (str : :mod:`master_discovery_fkie.master_info.TopicInfo`)
     '''
     return self.__topiclist
@@ -835,9 +835,9 @@ class MasterInfo(object):
     '''
     Adds a new TopicInfo with given name. If the ``TopicInfo`` already exists, do
     nothing.
-    
+
     :param name: the name of new :mod:`master_discovery_fkie.master_info.TopicInfo`
-    
+
     :type name: str
     '''
     if (name is None) or not name:
@@ -849,7 +849,7 @@ class MasterInfo(object):
   def topic_names(self):
     '''
     :return: the list with topic names.
-    
+
     :rtype: list of strings
     '''
     return self.__topiclist.keys()
@@ -858,7 +858,7 @@ class MasterInfo(object):
   def services(self):
     '''
     :return: the dictionary with ``service names`` and corresponding ``ServiceInfo`` instances.
-    
+
     :rtype: dict of (str : :mod:`master_discovery_fkie.master_info.ServiceInfo`)
     '''
     return self.__servicelist
@@ -868,9 +868,9 @@ class MasterInfo(object):
     '''
     Adds a new :mod:`master_discovery_fkie.master_info.ServiceInfo` with given name. If the ServiceInfo already exists, do
     nothing.
-    
+
     :param name: the name of new :mod:`master_discovery_fkie.master_info.ServiceInfo`
-    
+
     :type name: str
     '''
     if (name is None) or not name:
@@ -882,7 +882,7 @@ class MasterInfo(object):
   def service_names(self):
     '''
     :return: the list with service names.
-    
+
     :rtype: list of strings
     '''
     return self.__servicelist.keys()
@@ -891,7 +891,7 @@ class MasterInfo(object):
   def service_uris(self):
     '''
     :return: the list with service URI's.
-    
+
     :rtype: list of strings
     '''
     uris = []
@@ -902,11 +902,11 @@ class MasterInfo(object):
   def getNode(self, name):
     '''
     :param name: the name of the node
-    
+
     :type name: str
-    
+
     :return: the instance of the :mod:`master_discovery_fkie.master_info.NodeInfo` with given name
-    
+
     :rtype: :mod:`master_discovery_fkie.master_info.NodeInfo` or ``None``
     '''
     if (name is None) or not name:
@@ -916,13 +916,13 @@ class MasterInfo(object):
   def getNodeEndsWith(self, suffix):
     '''
     Returns the node, which name ends with given suffix. On more then one node, only the fist found will be returned.
-    
+
     :param suffix: the end of the name
-    
+
     :type suffix: str
-    
+
     :return: the instance of the :mod:`master_discovery_fkie.master_info.NodeInfo` with with given suffix
-    
+
     :rtype: :mod:`master_discovery_fkie.master_info.NodeInfo` or ``None``
     '''
     if (suffix is None) or not suffix:
@@ -935,13 +935,13 @@ class MasterInfo(object):
   def getTopic(self, name):
     '''
     Returns the topics with given name.
-    
+
     :param name: the name of the topic
-    
+
     :type name: str
-    
+
     :return: the instance of the :mod:`master_discovery_fkie.master_info.TopicInfo` with given name.
-    
+
     :rtype: :mod:`master_discovery_fkie.master_info.TopicInfo` or ``None``
     '''
     if (name is None) or not name:
@@ -951,30 +951,30 @@ class MasterInfo(object):
   def getService(self, name):
     '''
     Returns the service with given name.
-    
+
     :param name: the name of the service
-    
+
     :type name: str
-    
+
     :return: the instance of the :mod:`master_discovery_fkie.master_info.ServiceInfo` with given name
-    
+
     :rtype: :mod:`master_discovery_fkie.master_info.ServiceInfo` or ``None``
     '''
     if (name is None) or not name:
       return None
     return self.__servicelist.get(name, None)
-  
+
   def __eq__(self, other):
     '''
-    Compares the master state with other master state. The timestamp will not be 
+    Compares the master state with other master state. The timestamp will not be
     compared.
-    
+
     :param other: the another MasterInfo instance.
-    
+
     :type other: :mod:`master_discovery_fkie.master_info.MasterInfo`
-    
+
     :return: ``True``, if the states are equal.
-    
+
     :rtype: boolean
     '''
 #    import os                                ###################
@@ -1015,21 +1015,21 @@ class MasterInfo(object):
 #      cputimes = os.times() ###################
 #      print "EQ:", (cputimes[0] + cputimes[1] - cputime_init), ", count nodes:", len(self.node_names) ###################
 
-  
+
   def __ne__(self, other):
     return not self.__eq__(other)
-  
+
   def has_local_changes(self, other):
     '''
-    Compares the master state with other master state. The timestamp will not be 
+    Compares the master state with other master state. The timestamp will not be
     compared.
-    
+
     :param other: the another ``MasterInfo`` instance.
-    
+
     :type other: :mod:`master_discovery_fkie.master_info.MasterInfo`
-    
+
     :return: a tupel with two boolean values (all equal, only local equal)
-    
+
     :rtype: (bool, bool)
     '''
 #    import os                                ###################
@@ -1088,53 +1088,53 @@ class MasterInfo(object):
 #    finally:
 #      cputimes = os.times() ###################
 #      print "CHANGES:", (cputimes[0] + cputimes[1] - cputime_init), ", count nodes:", len(self.node_names) ###################
-  
+
   def listedState(self, filter_interface=None):
     '''
     Returns a extended ROS Master State.
-    
+
     :param filter_interface: The filter used to filter the nodes, topics or serivces out.
-    
+
     :type filter_interface: FilterInterface
-    
+
     :return: complete ROS Master State as
-             
+
              ``(stamp, stamp_local, masteruri, name, publishers, subscribers, services, topicTypes, nodes, serviceProvider)``
-             
+
                - ``publishers`` is of the form
-                 
+
                  ``[ [topic1, [topic1Publisher1...topic1PublisherN]] ... ]``
-               
+
                - ``subscribers`` is of the form
-                 
+
                  ``[ [topic1, [topic1Subscriber1...topic1SubscriberN]] ... ]``
-               
+
                - ``services`` is of the form
-                 
+
                  ``[ [service1, [service1Provider1...service1ProviderN]] ... ]``
-               
-               - ``topicTypes`` is a list of 
-                 
+
+               - ``topicTypes`` is a list of
+
                  ``[ [topicName1, topicType1], ... ]``
-               
+
                - ``nodes`` is a list of (the pid of remote Nodes will not be resolved)
-                 
+
                  ``[nodename, XML-RPC URI, origin ROS_MASTER_URI, pid, {local, remote}]``
-               
+
                - ``serviceProvider`` is a list of (the type, serviceClass and args of remote Services will not be resolved)
-                 
+
                  ``[service, XML-RPC URI, origin ROS_MASTER_URI, type, {local, remote}]``
-               
-    
+
+
     :rtype: (``float``,
              ``float``,
              ``str``,
              ``str``,
-             ``[ [str,[str] ] ]``, 
-             ``[ [str,[str] ] ]``, 
-             ``[ [str,[str] ] ]``, 
-             ``[ [str,str] ]``, 
-             ``[ [str,str,str,int,str] ]``, 
+             ``[ [str,[str] ] ]``,
+             ``[ [str,[str] ] ]``,
+             ``[ [str,[str] ] ]``,
+             ``[ [str,str] ]``,
+             ``[ [str,str,str,int,str] ]``,
              ``[ [str,str,str,str,str] ])``
     '''
     iffilter = filter_interface
@@ -1156,7 +1156,7 @@ class MasterInfo(object):
         if filter_interface is None or node.isLocal or (iffilter.sync_remote_nodes() and self.masteruri == str(node.masteruri)):
           added_nodes.append(name)
 
-    # filter the topics 
+    # filter the topics
     for name, topic in self.topics.items():
       pn = []
       for n in topic.publisherNodes:
@@ -1176,7 +1176,7 @@ class MasterInfo(object):
         subscribers.append((name, sn))
       if pn or sn:
         topicTypes.append((name, topic.type))
-    
+
     # filter the services
     for name, service in self.services.items():
       srv_prov = []
@@ -1201,9 +1201,9 @@ class MasterInfo(object):
 
   def updateInfo(self, other):
     '''
-    Updates the information about nodes, topics and services. If the other 
+    Updates the information about nodes, topics and services. If the other
     masterinfo is from the same ROS Master all informations are copied. If other
-    contains the info from remote ROS Master, only the informations for 
+    contains the info from remote ROS Master, only the informations for
     synchronized nodes, topics or services are copied.
     :param other: the new master information object
     :type other: MasterInfo
@@ -1268,7 +1268,7 @@ class MasterInfo(object):
           del self.__nodelist[n]
       else:
         pass
-        # if the node is in own master_info, but not in remote, replace only the masteruri. 
+        # if the node is in own master_info, but not in remote, replace only the masteruri.
         # perhaps, if will be removed soon by master_sync
 #        for n in nodes2remove:
 #          own_remote_nodes[n].masteruri = self.masteruri
@@ -1323,7 +1323,7 @@ class MasterInfo(object):
         for s in srvs2remove:
           del self.__servicelist[s]
       else:
-        # if the service is in own master_info, but not in remote, replace only the masteruri. 
+        # if the service is in own master_info, but not in remote, replace only the masteruri.
         # perhaps, if will be removed soon by master_sync
         for s in srvs2remove:
           own_remote_srvs[s].masteruri = self.masteruri

--- a/master_discovery_fkie/src/master_discovery_fkie/master_monitor.py
+++ b/master_discovery_fkie/src/master_discovery_fkie/master_monitor.py
@@ -373,7 +373,7 @@ class MasterMonitor(object):
         except:
           import traceback
           with self._lock:
-            self._limited_log(service, "can't get service type: %s"%traceback.format_exc())
+            self._limited_log(service, "can't get service type: %s" % traceback.format_exc(), rospy.ERROR)
 #          print traceback.format_exc()
 #          print "_getServiceInfo _lock try..", threading.current_thread()
           with self._lock:
@@ -663,12 +663,21 @@ class MasterMonitor(object):
 
       return master_state
 
-  def _limited_log(self, provider, msg):
+  def _limited_log(self, provider, msg, level=rospy.WARN):
     if not provider in self._printed_errors:
       self._printed_errors[provider] = dict()
     if not msg in self._printed_errors[provider]:
       self._printed_errors[provider][msg] = time.time()
-      rospy.logwarn("MasterMonitor[%s]: %s"%(provider, msg))
+      if level == rospy.DEBUG:
+        rospy.logdebug("MasterMonitor[%s]: %s" % (provider, msg))
+      elif level == rospy.INFO:
+        rospy.loginfo("MasterMonitor[%s]: %s" % (provider, msg))
+      elif level == rospy.WARN:
+        rospy.logwarn("MasterMonitor[%s]: %s" % (provider, msg))
+      elif level == rospy.ERROR:
+        rospy.logerr("MasterMonitor[%s]: %s" % (provider, msg))
+      elif level == rospy.FATAL:
+        rospy.logfatal("MasterMonitor[%s]: %s" % (provider, msg))
 
   def _clearup_cached_logs(self, age=300):
     cts = time.time()

--- a/master_discovery_fkie/src/master_discovery_fkie/master_monitor.py
+++ b/master_discovery_fkie/src/master_discovery_fkie/master_monitor.py
@@ -43,6 +43,7 @@ import subprocess
 import roslib; roslib.load_manifest('master_discovery_fkie')
 import roslib.network
 import rospy
+import os
 
 try: # to avoid the problems with autodoc on ros.org/wiki site
   from multimaster_msgs_fkie.msg import LinkState, LinkStatesStamped, MasterState, ROSMaster, SyncMasterInfo, SyncTopicInfo, SyncServiceInfo
@@ -75,24 +76,24 @@ class RPCThreadingV6(ThreadingMixIn, SimpleXMLRPCServer):
 
 class MasterMonitor(object):
   '''
-  This class provides methods to get the state from the ROS master using his 
+  This class provides methods to get the state from the ROS master using his
   RPC API and test for changes. Furthermore an XML-RPC server will be created
   to offer the complete current state of the ROS master by one method call.
 
   :param rpcport: the port number for the XML-RPC server
-  
+
   :type rpcport:  int
-  
+
   :param do_retry: retry to create XML-RPC server
-  
+
   :type do_retry: bool
 
   :see: :mod:`master_discovery_fkie.master_monitor.MasterMonitor.getCurrentState()`, respectively
         :mod:`master_discovery_fkie.master_monitor.MasterMonitor.updateState()`
-  
+
   :RPC Methods:
-      :mod:`master_discovery_fkie.master_monitor.MasterMonitor.getListedMasterInfo()` or 
-      :mod:`master_discovery_fkie.master_monitor.MasterMonitor.getMasterContacts()` as RPC: 
+      :mod:`master_discovery_fkie.master_monitor.MasterMonitor.getListedMasterInfo()` or
+      :mod:`master_discovery_fkie.master_monitor.MasterMonitor.getMasterContacts()` as RPC:
       ``masterInfo()`` and ``masterContacts()``
   '''
 
@@ -105,17 +106,17 @@ class MasterMonitor(object):
     '''
     Initialize method. Creates an XML-RPC server on given port and starts this
     in its own thread.
-    
+
     :param rpcport: the port number for the XML-RPC server
-    
+
     :type rpcport:  int
-    
+
     :param do_retry: retry to create XML-RPC server
-    
+
     :type do_retry: bool
-    
+
     :param ipv6: Use ipv6
-    
+
     :type ipv6: bool
     '''
     self._state_access_lock = threading.RLock()
@@ -143,6 +144,19 @@ class MasterMonitor(object):
 
     self._master_errors = list()
 
+    # Get the interface to bind to for mcast discovery and xml-rpc.
+    # Use the ~interface param unless ROS_IP is set, use that explicitly
+    # otherwise.
+    self.interface = rospy.get_param('~interface', '')
+    if not self.interface and 'ROS_IP' in os.environ:
+      self.interface = os.environ['ROS_IP']
+      rospy.loginfo("Using user set ROS_IP for interface: %s", self.interface)
+    # Log what interface we're binding to.
+    if self.interface == "":
+      rospy.loginfo("Interface to bind: Default interface")
+    else:
+      rospy.loginfo("Interface to bind: %s", self.interface)
+
     # Create an XML-RPC server
     self.ready = False
     while not self.ready and (not rospy.is_shutdown()):
@@ -150,7 +164,7 @@ class MasterMonitor(object):
         RPCClass = RPCThreading
         if ipv6:
           RPCClass = RPCThreadingV6
-        self.rpcServer = RPCClass(('', rpcport), logRequests=False, allow_none=True)
+        self.rpcServer = RPCClass((self.interface, rpcport), logRequests=False, allow_none=True)
         rospy.loginfo("Start RPC-XML Server at %s", self.rpcServer.server_address)
         self.rpcServer.register_introspection_functions()
         self.rpcServer.register_function(self.getListedMasterInfo, 'masterInfo')
@@ -179,7 +193,7 @@ class MasterMonitor(object):
     # subscribe to get parameter updates
     rospy.loginfo("Subscribe to parameter `/roslaunch/uris`")
     self.__mycache_param_server = rospy.impl.paramserver.get_param_server_cache()
-    # HACK: use own method to get the updates also for parameters in the subgroup 
+    # HACK: use own method to get the updates also for parameters in the subgroup
     self.__mycache_param_server.update = self.__update_param
     # first access, make call to parameter server
     self._update_launch_uris_lock = threading.RLock()
@@ -252,13 +266,13 @@ class MasterMonitor(object):
     '''
     Gets process id of the node.
     This method blocks until the info is retrieved or socket timeout is reached (0.7 seconds).
-    
+
     :param nodename: the name of the node
-    
+
     :type nodename: str
-    
+
     :param uri: the uri of the node
-    
+
     :type uri: str
     '''
     for (nodename, uri) in nodes.items():
@@ -306,15 +320,15 @@ class MasterMonitor(object):
 
   def _getServiceInfo(self, services):
     '''
-    Gets service info through the RPC interface of the service. 
+    Gets service info through the RPC interface of the service.
     This method blocks until the info is retrieved or socket timeout is reached (0.5 seconds).
-    
+
     :param service: the name of the service
-    
+
     :type service: str
-    
+
     :param uri: the uri of the service
-    
+
     :type uri: str
     '''
     for (service, uri) in services.items():
@@ -378,8 +392,8 @@ class MasterMonitor(object):
   def getListedMasterInfo(self):
     '''
     :return: a extended ROS Master State.
-    
-    :rtype:  :mod:`master_discovery_fkie.master_info.MasterInfo.listedState()` for result type 
+
+    :rtype:  :mod:`master_discovery_fkie.master_info.MasterInfo.listedState()` for result type
     '''
     #'print "MASTERINFO ===================="
     t = str(time.time())
@@ -400,8 +414,8 @@ class MasterMonitor(object):
   def getListedMasterInfoFiltered(self, filter_list):
     '''
     :return: a extended filtered ROS Master State.
-    
-    :rtype:  :mod:`master_discovery_fkie.master_info.MasterInfo.listedState()` for result type 
+
+    :rtype:  :mod:`master_discovery_fkie.master_info.MasterInfo.listedState()` for result type
     '''
     #'print "MASTERINFO ===================="
     t = str(time.time())
@@ -424,7 +438,7 @@ class MasterMonitor(object):
   def getCurrentState(self):
     '''
     :return: The current ROS Master State
-    
+
     :rtype: :mod:`master_discovery_fkie.master_info.MasterInfo` or ``None``
     '''
     #'print "getCurrentState _state_access_lock try...", threading.current_thread()
@@ -436,16 +450,16 @@ class MasterMonitor(object):
   def updateState(self, clear_cache=False):
     '''
     Gets state from the ROS Master through his RPC interface.
-    
+
     :param clear_cache: The URI of nodes and services will be cached to reduce the load.
-                        If remote hosted nodes or services was restarted, the cache must 
+                        If remote hosted nodes or services was restarted, the cache must
                         be cleared! The local nodes will be updated periodically after
                         :mod:`master_discovery_fkie.master_monitor.MasterMonitor.MAX_PING_SEC`.
-    
-    :type clear_cache: bool (Default: ``False``) 
-    
+
+    :type clear_cache: bool (Default: ``False``)
+
     :rtype: :mod:`master_discovery_fkie.master_info.MasterInfo`
-    
+
     :raise: ``MasterConnectionException``, if not complete information was get from the ROS master.
     '''
     #'print "updateState _create_access_lock try...", threading.current_thread()
@@ -517,7 +531,7 @@ class MasterMonitor(object):
 #        cputime_init2 = cputimes2[0] + cputimes2[1] ###################
 #        cputimes = os.times()                                            ###################
 #        print "Auswertung: ", (cputimes[0] + cputimes[1] - cputime_init) ###################
-  
+
         # add services
 #        cputimes = os.times()                    ###################
 #        cputime_init = cputimes[0] + cputimes[1] ###################
@@ -628,9 +642,9 @@ class MasterMonitor(object):
 
 #      cputimes = os.times()                    ###################
 #      cputime_init = cputimes[0] + cputimes[1] ###################
-      
+
 #      print "threads:", len(threads)
-      # wait for all threads are finished 
+      # wait for all threads are finished
       while threads:
         th = threads.pop()
         if th.isAlive():
@@ -668,9 +682,9 @@ class MasterMonitor(object):
   def updateSyncInfo(self):
     '''
     This method can be called to update the origin ROS master URI of the nodes
-    and services in new ``master_state``. This is only need, if a synchronization is 
+    and services in new ``master_state``. This is only need, if a synchronization is
     running. The synchronization service will be detect automatically by searching
-    for the service ending with ``get_sync_info``. The method will be called by 
+    for the service ending with ``get_sync_info``. The method will be called by
     :mod:`master_discovery_fkie.master_monitor.MasterMonitor.checkState()`.
     '''
     #'print "updateSyncInfo _create_access_lock try...", threading.current_thread()
@@ -732,11 +746,11 @@ class MasterMonitor(object):
 
   def getMasteruri(self):
     '''
-    Requests the ROS master URI from the ROS master through the RPC interface and 
+    Requests the ROS master URI from the ROS master through the RPC interface and
     returns it.
-    
+
     :return: ROS master URI
-    
+
     :rtype: str or ``None``
     '''
     code = -1
@@ -747,11 +761,11 @@ class MasterMonitor(object):
 
   def getMastername(self):
     '''
-    Returns the name of the master. If no name is set, the hostname of the 
+    Returns the name of the master. If no name is set, the hostname of the
     ROS master URI will be extracted.
-    
+
     :return: the name of the ROS master
-    
+
     :rtype: str or ``None``
     '''
     if self.__mastername is None:
@@ -767,11 +781,11 @@ class MasterMonitor(object):
       except:
         pass
     return self.__mastername
-  
+
   def getMasterContacts(self):
     '''
     The RPC method called by XML-RPC server to request the master contact information.
-    
+
     :return: (``timestamp of the ROS master state``, ``ROS master URI``, ``master name``, ``name of this service``, ``URI of this RPC server``)
     :rtype: (str, str, str, str, str)
     '''
@@ -829,14 +843,14 @@ class MasterMonitor(object):
     Gets the state from the ROS master and compares it to the stored state.
 
     :param clear_cache: The URI of nodes and services will be cached to reduce the load.
-                        If remote hosted nodes or services was restarted, the cache must 
+                        If remote hosted nodes or services was restarted, the cache must
                         be cleared! The local nodes will be updated periodically after
                         :mod:`master_discovery_fkie.master_monitor.MasterMonitor.MAX_PING_SEC`.
-    
-    :type clear_cache: bool (Default: ``False``) 
+
+    :type clear_cache: bool (Default: ``False``)
 
     :return: ``True`` if the ROS master state is changed
-    
+
     :rtype: bool
     '''
     result = False
@@ -867,7 +881,7 @@ class MasterMonitor(object):
 
   def reset(self):
     '''
-    Sets the master state to ``None``. 
+    Sets the master state to ``None``.
     '''
     #'print "reset _state_access_lock try...", threading.current_thread()
     with self._state_access_lock:

--- a/master_discovery_fkie/src/master_discovery_fkie/udp.py
+++ b/master_discovery_fkie/src/master_discovery_fkie/udp.py
@@ -30,60 +30,62 @@
 # ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-import os
 import socket
 import struct
 import fcntl
 import array
 import platform
+import errno
 
 import rospy
 
 class McastSocket(socket.socket):
   '''
-  The McastSocket class enables the send and receive UDP messages to a multicast 
+  The McastSocket class enables the send and receive UDP messages to a multicast
   group.
-  
+
+  :param interface: The interface to bind to
+  :type interface: string
   :param port: the port to bind the socket
-  
   :type port: int
-  
   :param mgroup: the multicast group to join
-  
   :type mgroup: str
-  
-  :param reuse: allows the reusing of the port
-  
-  :type reuse: boolean (Default: True)
-  
   :param ttl: time to leave
-  
   :type ttl: int (Default: 20)
   '''
 
-  def __init__(self, port, mgroup, reuse=True, ttl=20):
+  def __init__(self, interface, port, mgroup, ttl=20):
     '''
     Creates a socket, bind it to a given port and join to a given multicast group.
     IPv4 and IPv6 are supported.
+
     @param port: the port to bind the socket
     @type port: int
     @param mgroup: the multicast group to join
     @type mgroup: str
-    @param reuse: allows the reusing of the port
-    @type reuse: boolean (Default: True)
     @param ttl: time to leave
     @type ttl: int (Default: 20)
     '''
-    addrinfo = McastSocket.getaddrinfo(mgroup)
+    # Set multicast group for sending to multicast
+    self.mgroup = mgroup
+    self.interface = interface
+
+    # Get AF_INET information for interface if specified.
+    # Otherwise get the AF_INET information for group so we have something.
+    addrinfo = None
+    if not self.interface:
+      addrinfo = McastSocket.getaddrinfo(mgroup)
+    else:
+      addrinfo = McastSocket.getaddrinfo(interface)
+
     socket.socket.__init__(self, addrinfo[0], socket.SOCK_DGRAM, socket.IPPROTO_UDP)
 
     # Allow multiple copies of this program on one machine
-    if(reuse):
-      self.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-      if hasattr(socket, "SO_REUSEPORT"):
-        self.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEPORT, 1)
-    # Bind to the port
-    self.bind(('', port))
+    # Required to receive unicast UDP
+    self.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    if hasattr(socket, "SO_REUSEPORT"):
+      self.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEPORT, 1)
+
     # Set Time-to-live (optional) and loop count
     ttl_bin = struct.pack('@i', ttl)
     if addrinfo[0] == socket.AF_INET: # IPv4
@@ -93,45 +95,60 @@ class McastSocket(socket.socket):
       self.setsockopt(socket.IPPROTO_IPV6, socket.IPV6_MULTICAST_HOPS, ttl_bin)
       self.setsockopt(socket.IPPROTO_IPV6, socket.IPV6_MULTICAST_LOOP, 1)
 
-    #join to the multicast group 
-    group_bin = socket.inet_pton(addrinfo[0], McastSocket.normalize_mgroup(mgroup))
+    #join to the multicast group
+    rospy.logdebug("mgroup: %s", mgroup)
+    rospy.logdebug("interface : %s", interface)
+    rospy.logdebug("inet: %s", addrinfo)
+
     try:
       if addrinfo[0] == socket.AF_INET: # IPv4
-        mreq = group_bin + struct.pack('=I', socket.INADDR_ANY)
-        self.setsockopt(socket.IPPROTO_IP, socket.IP_ADD_MEMBERSHIP, mreq)
+        # Create group_bin for de-register later
+        # Set socket options for multicast specific interface or general
+        if not self.interface:
+          self.group_bin = socket.inet_pton(socket.AF_INET, mgroup) + struct.pack('=I', socket.INADDR_ANY)
+          self.setsockopt(socket.IPPROTO_IP, socket.IP_ADD_MEMBERSHIP,
+                          self.group_bin)
+        else:
+          self.group_bin = socket.inet_aton(mgroup) + socket.inet_aton(self.interface)
+          self.setsockopt(socket.IPPROTO_IP,
+                          socket.IP_MULTICAST_IF,
+                          socket.inet_aton(self.interface))
+          self.setsockopt(socket.IPPROTO_IP,
+                          socket.IP_ADD_MEMBERSHIP,
+                          self.group_bin)
       else: #IPv6
-        mreq = group_bin + struct.pack('@I', 0)
-        self.setsockopt(socket.IPPROTO_IPV6, socket.IPV6_JOIN_GROUP, mreq)
+        # Create group_bin for de-register later
+        # Set socket options for multicast
+        self.group_bin = socket.inet_pton(addrinfo[0], mgroup) + struct.pack('@I', socket.INADDR_ANY)
+        self.setsockopt(socket.IPPROTO_IPV6,
+                        socket.IPV6_JOIN_GROUP,
+                        self.group_bing)
+
     except socket.error, (errn, msg):
       err = str(msg)
       if errn in [19]:
         err = ''.join(["socket.error[", str(errn), "]: ", msg, ",\nis multicast route set? e.g. sudo route add -net 224.0.0.0 netmask 224.0.0.0 eth0"])
       raise Exception(err)
 
+    # Bind to the port
+    try:
+      self.bind((mgroup, port))
+    except socket.error, (errn, msg):
+      err = str(msg)
+      rospy.logfatal("Unable to bind to interface: %s, check that it exists: %s",
+                     self.interface, err)
+      raise
+
     self.addrinfo = addrinfo
-    self.group_bin = group_bin
     self.sock_5_error_printed = []
 
   @staticmethod
-  def getaddrinfo(mgroup):
+  def getaddrinfo(addr):
     # get info about the IP version (4 or 6)
-    groupaddr, interface = McastSocket.normalize_mgroup(mgroup, True)
-    addrinfos = socket.getaddrinfo(groupaddr, None)
+    addrinfos = socket.getaddrinfo(addr, None)
     addrinfo = None
     if len(addrinfos) > 1:
       addrinfo = addrinfos[0]
-      if not interface:
-        interface = rospy.get_param('~interface', '')
-      if not interface and 'ROS_IP' in os.environ:
-        interface = os.environ['ROS_IP']
-      if interface:
-        addrinfos = socket.getaddrinfo(interface, None)
-        if len(addrinfos) >= 1:
-          rospy.loginfo("  Use userdefined interface %s to send multicast messages"%interface)
-          return addrinfos[0]
-      rospy.loginfo(" Use first of %d interfaces to send multicast messages"%len(addrinfos))
-    else:
-      return addrinfos[0]
     return addrinfo
 
   @staticmethod
@@ -145,59 +162,38 @@ class McastSocket(socket.socket):
     '''
     Unregister from the multicast group and close the socket.
     '''
+    # Use the stored group_bin to de-register
     if self.addrinfo[0] == socket.AF_INET: # IPv4
-        mreq = self.group_bin + struct.pack('=I', socket.INADDR_ANY)
-        self.setsockopt(socket.IPPROTO_IP, socket.IP_DROP_MEMBERSHIP, mreq)
+        self.setsockopt(socket.IPPROTO_IP, socket.IP_DROP_MEMBERSHIP, self.group_bin)
     else: #IPv6
-        mreq = self.group_bin + struct.pack('@I', 0)
-        self.setsockopt(socket.IPPROTO_IPV6, socket.IPV6_LEAVE_GROUP, mreq)
+        self.setsockopt(socket.IPPROTO_IPV6,
+                        socket.IPV6_LEAVE_GROUP,
+                        self.group_bing)
     socket.socket.close(self)
 
   def send2group(self, msg):
     '''
-    Sends the given message to the joined multicast group. Some errors on send 
+    Sends the given message to the joined multicast group. Some errors on send
     will be ignored (``ENETRESET``, ``ENETDOWN``, ``ENETUNREACH``)
-    
-    :param msg: message to send
-    
-    :type msg: str
-    '''
-    try:
-      self.sendto(msg, (self.addrinfo[4][0], self.getsockname()[1]))
-    except socket.error, (errn, msg):
-      if not errn in [100, 101, 102]:
-        raise
 
-  def send2addr(self, msg, addr):
-    '''
-    Sends the given message to the joined multicast group. Some errors on send 
-    will be ignored (``ENETRESET``, ``ENETDOWN``, ``ENETUNREACH``)
-    
     :param msg: message to send
-    
     :type msg: str
-    
-    :param addr: IPv4 or IPv6 address
-    
-    :type addr: str
     '''
     try:
-      self.sendto(msg, (addr, self.getsockname()[1]))
+      # Send to the multicast group address as supplied
+      # Default '226.0.0.0'
+      self.sendto(msg, (self.mgroup, self.getsockname()[1]))
     except socket.error, (errn, msg):
-      if errn in [-5]:
-        if not addr in self.sock_5_error_printed:
-          rospy.logwarn("socket.error[%d]: %s, addr: %s", errn, msg, addr)
-          self.sock_5_error_printed.append(addr)
-      elif not errn in [100, 101, 102]:
+      if not errn in [errno.ENETDOWN, errno.ENETUNREACH, errno.ENETRESET]:
         raise
 
   def hasEnabledMulticastIface(self):
     '''
-    Test all enabled interfaces for a MULTICAST flag. If no enabled interfaces 
+    Test all enabled interfaces for a MULTICAST flag. If no enabled interfaces
     has a multicast support, False will be returned.
-    
+
     :return: ``True``, if any interfaces with multicast support are enabled.
-    
+
     :rtype: bool
     '''
     SIOCGIFFLAGS = 0x8913
@@ -219,18 +215,17 @@ class McastSocket(socket.socket):
     '''
     Used to get a list of the up interfaces and associated IP addresses
     on this machine (linux only).
-  
+
     :return:
         List of interface tuples.  Each tuple consists of
         ``(interface name, interface IP)``
-    
     :rtype: list of ``(str, str)``
     '''
     SIOCGIFCONF = 0x8912
     MAXBYTES = 8096
-  
+
     arch = platform.architecture()[0]
-  
+
     # I really don't know what to call these right now
     var1 = -1
     var2 = -1
@@ -242,7 +237,7 @@ class McastSocket(socket.socket):
       var2 = 40
     else:
       raise OSError("Unknown architecture: %s" % arch)
-  
+
     sockfd = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
     names = array.array('B', '\0' * MAXBYTES)
     outbytes = struct.unpack('iL', fcntl.ioctl(
@@ -250,7 +245,87 @@ class McastSocket(socket.socket):
         SIOCGIFCONF,
         struct.pack('iL', MAXBYTES, names.buffer_info()[0])
         ))[0]
-  
+
     namestr = names.tostring()
     return [(namestr[i:i+var1].split('\0', 1)[0], socket.inet_ntoa(namestr[i+20:i+24])) \
             for i in xrange(0, outbytes, var2)]
+
+
+class UcastSocket(socket.socket):
+
+  def __init__(self, interface, port):
+    '''
+    Creates a socket, bind it to a given interface+port for unicast send/receive.
+    IPv4 and IPv6 are supported.
+
+    @param interface: The interface to bind to
+    @type interface: str
+    @param port: the port to bind the socket
+    @type port: int
+    '''
+    # Set multicast group for sending to multicast
+    self.interface = interface
+
+    # Get AF_INET information for interface if specified.
+    # Otherwise get the AF_INET information for group so we have something.
+    addrinfo = None
+
+    # If interface isn't specified, use localhost to get some info for binding
+    # (AF_INET etc...)
+    if not self.interface:
+      addrinfo = UcastSocket.getaddrinfo('localhost')
+    else:
+      # Otherwise get the address info for the interface specified.
+      addrinfo = UcastSocket.getaddrinfo(interface)
+
+    # Configure socket type
+    socket.socket.__init__(self, addrinfo[0], socket.SOCK_DGRAM, socket.IPPROTO_UDP)
+
+    # Allow multiple copies of this program on one machine
+    # Required to receive unicast UDP
+    self.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    if hasattr(socket, "SO_REUSEPORT"):
+      self.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEPORT, 1)
+
+    # Bind to the port
+    try:
+      rospy.logdebug("Ucast bind to: (%s:%s)", interface, port)
+      self.bind((interface, port))
+    except socket.error, (errn, msg):
+      err = str(msg)
+      rospy.logfatal("Unable to bind to interface: %s, check that it exists: %s",
+                     self.interface, err)
+      raise
+
+  def send2addr(self, msg, addr):
+    '''
+    Sends the given message to the joined multicast group. Some errors on send
+    will be ignored (``ENETRESET``, ``ENETDOWN``, ``ENETUNREACH``)
+
+    :param msg: message to send
+    :type msg: str
+    :param addr: IPv4 or IPv6 address
+    :type addr: str
+    '''
+    try:
+      self.sendto(msg, (addr, self.getsockname()[1]))
+    except socket.error, (errn, msg):
+      if errn in [-5]:
+        if not addr in self.sock_5_error_printed:
+          rospy.logwarn("socket.error[%d]: %s, addr: %s", errn, msg, addr)
+          self.sock_5_error_printed.append(addr)
+      elif not errn in [errno.ENETDOWN, errno.ENETUNREACH, errno.ENETRESET]:
+        raise
+
+  def close(self):
+    """ Cleanup and close the socket"""
+    socket.socket.close()
+
+  @staticmethod
+  def getaddrinfo(addr):
+    # get info about the IP version (4 or 6)
+    addrinfos = socket.getaddrinfo(addr, None)
+    addrinfo = None
+    if len(addrinfos) > 1:
+      addrinfo = addrinfos[0]
+    return addrinfo

--- a/master_sync_fkie/src/master_sync_fkie/sync_thread.py
+++ b/master_sync_fkie/src/master_sync_fkie/sync_thread.py
@@ -237,7 +237,7 @@ class SyncThread(object):
         handler(remote_state)
     except:
       import traceback
-      rospy.logwarn("SyncThread[%s] ERROR: %s", self.name, traceback.format_exc())
+      rospy.logerr("SyncThread[%s] ERROR: %s", self.name, traceback.format_exc())
     finally:
       self.__on_update = False
       socket.setdefaulttimeout(None)
@@ -399,7 +399,7 @@ class SyncThread(object):
           self._update_timer.start()
     except:
       import traceback
-      rospy.logwarn("SyncThread[%s] ERROR: %s", self.name, traceback.format_exc())
+      rospy.logerr("SyncThread[%s] ERROR: %s", self.name, traceback.format_exc())
     finally:
       socket.setdefaulttimeout(None)
 
@@ -423,7 +423,7 @@ class SyncThread(object):
         rospy.logdebug("    SyncThread[%s] finished", self.name)
       except:
         import traceback
-        rospy.logwarn("SyncThread[%s] ERROR while ending: %s", self.name, traceback.format_exc())
+        rospy.logerr("SyncThread[%s] ERROR while ending: %s", self.name, traceback.format_exc())
       socket.setdefaulttimeout(None)
 
   def _doIgnoreNTP(self, node, topic, topictype):


### PR DESCRIPTION
If you want to use something that isn't the default route ( e.g. Ethernet for internet, but WiFi for the multimaster network), you need to be able to specify the network to bind to. By default multimaster binds to the default interface and will not discover other masters in the case outlined above.

This PR addresses the previous use case and allows multimaster_fkie to bind to a non default interface by specifying the interface via a ROS param ('~interface') or by setting the ROS_IP envvar.

Some other changes introduced
* added a second listener socket (unicast) to allow for unicast UDP traffic to be received, since we were unable to send unicast traffic with the same multicast socket.
* Don't exit if we're on localhost, just log a warning
* Added support for different logging levels in master_monitor: currently all logs are marked as warnings, where some should be marked as errors.

