### PR TITLE
multimaster_fkie: Set correct logging level to warning

### DIFF
--- a/master_discovery_fkie/src/master_discovery_fkie/master_monitor.py
+++ b/master_discovery_fkie/src/master_discovery_fkie/master_monitor.py
@@ -361,7 +361,7 @@ class MasterMonitor(object):
         except:
           import traceback
           with self._lock:
-            self._limited_log(service, "can't get service type: %s" % traceback.format_exc(), rospy.ERROR)
+            self._limited_log(service, "can't get service type: %s" % traceback.format_exc(), rospy.WARN)
 #          print traceback.format_exc()
 #          print "_getServiceInfo _lock try..", threading.current_thread()
           with self._lock:


### PR DESCRIPTION
As mentioned by @atiderko in https://github.com/fkie/multimaster_fkie/issues/30, the level for this particular log should be WARN.