### PR TITLE
Support hub topology by adding favor_unicast param

### DIFF
--- a/master_discovery_fkie/launch/master_discovery.launch
+++ b/master_discovery_fkie/launch/master_discovery.launch
@@ -34,5 +34,7 @@
     <param name="change_notification_count" value="3" />
     <!-- disables the send of multicast messages.  -->
     <param name="send_mcast" value="True" />
+    <!-- use unicast to send if discovered masters are on separate hosts -->
+    <param name="favor_unicast" value="False" />
   </node>
 </launch>

--- a/master_discovery_fkie/src/master_discovery_fkie/master_discovery.py
+++ b/master_discovery_fkie/src/master_discovery_fkie/master_discovery.py
@@ -588,6 +588,9 @@ class Discoverer(object):
         self._timer_ros_changes = threading.Timer(0.1, self.checkROSMaster_loop)
         # init socket for discovering. Exit on errors!
         self._init_socket(True)
+        if not self.socket.canUnicast() and self._favor_unicast:
+            rospy.logwarn("Unicast is not enabled.  Disabling favor_unicast!")
+            self._favor_unicast = False
         # create a timer monitor the offline ROS master and calculate the link qualities
         self._timer_stats = threading.Timer(1, self.timed_stats_calculation)
         # create timer and paramter for heartbeat notifications
@@ -710,7 +713,7 @@ class Discoverer(object):
             msg = self._create_current_state_msg()
             if msg is not None:
                 if self._favor_unicast and not self._has_multiple_addresses():
-                    self.socket.send2addr(self._create_request_update_msg(), self.socket.unicast_socket.interface)
+                    self.socket.send2unicastaddr(self._create_request_update_msg())
                     for address in self._addresses:
                         self.socket.send2addr(msg, address)
                 else:
@@ -738,7 +741,7 @@ class Discoverer(object):
                 rospy.logdebug('Send request to mcast group %s:%s' % (self.mcast_group, self.mcast_port))
                 # do not send a multicast request if one was received in last time
                 if self._favor_unicast and not self._has_multiple_addresses():
-                    self.socket.send2addr(self._create_request_update_msg(), self.socket.unicast_socket.interface)
+                    self.socket.send2unicastaddr(self._create_request_update_msg())
                     for address in self._addresses:
                         self.socket.send2addr(self._create_request_update_msg(), address)
                 else:

--- a/master_discovery_fkie/src/master_discovery_fkie/udp.py
+++ b/master_discovery_fkie/src/master_discovery_fkie/udp.py
@@ -237,7 +237,7 @@ class DiscoverSocket(socket.socket):
         '''
         try:
             if self.unicast_only and self.unicast_socket:
-                self.unicast_socket.send2addr(msg, self.unicast_socket.interface)
+                self.send2unicastaddr(msg)
             else:
                 # Send to the multicast group address as supplied
                 # Default '226.0.0.0'
@@ -246,6 +246,18 @@ class DiscoverSocket(socket.socket):
             msg = str(errobj)
             if errobj.errno not in [errno.ENETDOWN, errno.ENETUNREACH, errno.ENETRESET]:
                 raise
+    
+    def send2unicastaddr(self, msg):
+        '''
+        Sends the given message to the unicast interface.
+
+        :param msg: message to send
+
+        :type msg: str
+        '''
+        if self.unicast_socket:
+            self.unicast_socket.send2addr(msg, self.unicast_socket.interface)
+
 
     def send2addr(self, msg, addr):
         '''
@@ -296,6 +308,12 @@ class DiscoverSocket(socket.socket):
             if ((flags & IFF_MULTICAST) != 0) & ((flags & IFF_UP) != 0):
                 return True
         return False
+
+    def canUnicast(self):
+        '''
+        Returns True if the unicast_socket is available.
+        '''
+        return self.unicast_socket is not None
 
     @staticmethod
     def localifs():


### PR DESCRIPTION
In cases where multicast sending is enabled but favor_unicast is also set, we only listen for multicast messages to detect remote ROS masters and then use unicast to send out heartbeat requests and state.  What this allows us to do is deploy multimaster nodes as a hub rather than a mesh: master_discovery nodes with multicast and favor_unicast enabled with act as a client to any master_discovery nodes with multicast enabled but favor_unicast disabled.

The one caveat is that this can only work if all ROS masters are on a separate host.  If more than one master_discovery is on the same host we have to use multicast to ensure that all processes receive the heartbeat state/request messages.  In this case we default back to the 'normal' mesh like behavior.

This is useful for situations where:
1) Each ROS master is running on a separate host
2) Only one ROS master (hub) needs to talk to every other ROS master (hub clients)
3) We do not know beforehand the name or IP of the hub and want hub clients to attach to the hub automatically (otherwise we could disable multicast on each hub client and set the hub IP in the robot hosts param).