### PR TITLE
Augment CMake script to install node_manager launcher on Ubuntu.

### DIFF
--- a/node_manager_fkie/CMakeLists.txt
+++ b/node_manager_fkie/CMakeLists.txt
@@ -54,3 +54,24 @@ install(
    DESTINATION ${CATKIN_PACKAGE_PYTHON_DESTINATION}/editor/
 )
 
+# On Ubuntu, create and install a desktop launcher for node_manager.
+if (${CMAKE_SYSTEM_NAME} STREQUAL Linux)
+    # Define where to create the launcher file.
+    set(NODE_MANAGER_LAUNCHER ${CMAKE_CURRENT_BINARY_DIR}/node_manager.desktop)
+    
+    # Create the launcher file.
+    file(WRITE ${NODE_MANAGER_LAUNCHER} 
+        "[Desktop Entry]
+Name=node_manager
+Comment=GUI for managing running and configured ROS nodes on different hosts
+Exec=/bin/sh -c \". ${CMAKE_INSTALL_PREFIX}/setup.sh; ${CMAKE_INSTALL_PREFIX}/${CATKIN_PACKAGE_BIN_DESTINATION}/node_manager\"
+Icon=${CMAKE_INSTALL_PREFIX}/${CATKIN_PACKAGE_SHARE_DESTINATION}/rqt_icons/crystal_clear_prop_run.png
+Terminal=false
+Type=Application
+Categories=Utility;Development;"
+    )
+
+    # Install the launcher file.
+    install(CODE "set(NODE_MANAGER_LAUNCHER \"${NODE_MANAGER_LAUNCHER}\")")
+    install(SCRIPT InstallLauncher.cmake)
+endif(${CMAKE_SYSTEM_NAME} STREQUAL Linux)

--- a/node_manager_fkie/InstallLauncher.cmake
+++ b/node_manager_fkie/InstallLauncher.cmake
@@ -1,17 +1,12 @@
 # Install and register the given launcher file.
+message(STATUS "Installing Unity desktop launcher")
 execute_process(COMMAND 
         desktop-file-install --dir=$ENV{HOME}/.local/share/applications ${NODE_MANAGER_LAUNCHER} 
     RESULT_VARIABLE 
         LAUNCHER_INSTALLATION_RESULT
 )
 
-# Print the result.
-if (${LAUNCHER_INSTALLATION_RESULT} EQUAL 0)
-    set(LAUNCHER_INSTALLATION_RESULT success)
-endif (${LAUNCHER_INSTALLATION_RESULT} EQUAL 0)
-
-if (${LAUNCHER_INSTALLATION_RESULT} EQUAL 1)
-    set(LAUNCHER_INSTALLATION_RESULT failure)
-endif (${LAUNCHER_INSTALLATION_RESULT} EQUAL 1)
-
-message(STATUS "Installing Unity desktop launcher: ${LAUNCHER_INSTALLATION_RESULT}.")
+# If an error occurred, print it.
+if (NOT ${LAUNCHER_INSTALLATION_RESULT} EQUAL 0)
+    message(AUTHOR_WARNING "Installing Unity desktop launcher failed")
+endif (NOT ${LAUNCHER_INSTALLATION_RESULT} EQUAL 0)

--- a/node_manager_fkie/InstallLauncher.cmake
+++ b/node_manager_fkie/InstallLauncher.cmake
@@ -1,0 +1,17 @@
+# Install and register the given launcher file.
+execute_process(COMMAND 
+        desktop-file-install --dir=$ENV{HOME}/.local/share/applications ${NODE_MANAGER_LAUNCHER} 
+    RESULT_VARIABLE 
+        LAUNCHER_INSTALLATION_RESULT
+)
+
+# Print the result.
+if (${LAUNCHER_INSTALLATION_RESULT} EQUAL 0)
+    set(LAUNCHER_INSTALLATION_RESULT success)
+endif (${LAUNCHER_INSTALLATION_RESULT} EQUAL 0)
+
+if (${LAUNCHER_INSTALLATION_RESULT} EQUAL 1)
+    set(LAUNCHER_INSTALLATION_RESULT failure)
+endif (${LAUNCHER_INSTALLATION_RESULT} EQUAL 1)
+
+message(STATUS "Installing Unity desktop launcher: ${LAUNCHER_INSTALLATION_RESULT}.")


### PR DESCRIPTION
The changes made to the CMake script automatically install and register a program launcher when installing multimaster via `catkin_make install` on Ubuntu.

There are several advantages that come with installing a launcher:
1. It is very easy to start the application.
1. You do not have an idling terminal floating around, which is the case if starting via command line.
1. You do not need to manually source `setup.sh`. The launcher takes care of that.