### PR TITLE
fix: adjust for ros msg standarts

### DIFF
--- a/fkie_multimaster_msgs/msg/MasterState.msg
+++ b/fkie_multimaster_msgs/msg/MasterState.msg
@@ -1,6 +1,6 @@
 string state
 fkie_multimaster_msgs/ROSMaster master
 
-string STATE_NEW='new'
-string STATE_REMOVED='removed'
-string STATE_CHANGED='changed'
+string STATE_NEW=new
+string STATE_REMOVED=removed
+string STATE_CHANGED=changed


### PR DESCRIPTION
This message definition creates problems with several generators i.e. gennodejs.
For reference: https://wiki.ros.org/msg#Constants

Correct definition must look like following:
```
string RICK=morty
```

This is the problem that this message definition creates in js:
```js

// Constants for message
MasterState.Constants = {
  STATE_NEW: ''new'',
  STATE_REMOVED: ''removed'',
  STATE_CHANGED: ''changed'',
}
```
_There are way too many quotes_