### PR TITLE
Import setup from setuptools instead of distutils.core

### DIFF
--- a/fkie_master_discovery/package.xml
+++ b/fkie_master_discovery/package.xml
@@ -16,6 +16,8 @@
   <url>http://ros.org/wiki/master_discovery_fkie</url>
 
   <buildtool_depend>catkin</buildtool_depend>
+  <buildtool_depend condition="$ROS_PYTHON_VERSION == 2">python-setuptools</buildtool_depend>
+  <buildtool_depend condition="$ROS_PYTHON_VERSION == 3">python3-setuptools</buildtool_depend>
 
   <build_depend>fkie_multimaster_msgs</build_depend>
   <build_depend>std_srvs</build_depend>

--- a/fkie_master_discovery/setup.py
+++ b/fkie_master_discovery/setup.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-from distutils.core import setup
+from setuptools import setup
 from catkin_pkg.python_setup import generate_distutils_setup
 
 d = generate_distutils_setup(

--- a/fkie_master_sync/package.xml
+++ b/fkie_master_sync/package.xml
@@ -14,6 +14,8 @@
   <url>http://ros.org/wiki/master_sync_fkie</url>
   
   <buildtool_depend>catkin</buildtool_depend>
+  <buildtool_depend condition="$ROS_PYTHON_VERSION == 2">python-setuptools</buildtool_depend>
+  <buildtool_depend condition="$ROS_PYTHON_VERSION == 3">python3-setuptools</buildtool_depend>
   
   <build_depend>fkie_master_discovery</build_depend>
   <build_depend>fkie_multimaster_msgs</build_depend>

--- a/fkie_master_sync/package.xml
+++ b/fkie_master_sync/package.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<package format="2">
+<package format="3">
   <name>fkie_master_sync</name>
   <!-- <replace>master_sync_fkie</replace> -->
   <description>

--- a/fkie_master_sync/setup.py
+++ b/fkie_master_sync/setup.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-from distutils.core import setup
+from setuptools import setup
 from catkin_pkg.python_setup import generate_distutils_setup
 
 d = generate_distutils_setup(

--- a/fkie_multimaster/package.xml
+++ b/fkie_multimaster/package.xml
@@ -1,4 +1,4 @@
-<package format="2">
+<package format="3">
   <name>fkie_multimaster</name>
   <!-- <replace>multimaster_fkie</replace> -->
   <description>

--- a/fkie_node_manager/package.xml
+++ b/fkie_node_manager/package.xml
@@ -15,6 +15,8 @@
   <url>http://ros.org/wiki/node_manager_fkie</url>
   
   <buildtool_depend>catkin</buildtool_depend>
+  <buildtool_depend condition="$ROS_PYTHON_VERSION == 2">python-setuptools</buildtool_depend>
+  <buildtool_depend condition="$ROS_PYTHON_VERSION == 3">python3-setuptools</buildtool_depend>
   
   <build_depend condition="$ROS_PYTHON_VERSION == 2">python-catkin-pkg</build_depend>
   <build_depend condition="$ROS_PYTHON_VERSION == 3">python3-catkin-pkg</build_depend>

--- a/fkie_node_manager/setup.py
+++ b/fkie_node_manager/setup.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-from distutils.core import setup
+from setuptools import setup
 from catkin_pkg.python_setup import generate_distutils_setup
 
 d = generate_distutils_setup(

--- a/fkie_node_manager_daemon/package.xml
+++ b/fkie_node_manager_daemon/package.xml
@@ -11,6 +11,9 @@
   <url>https://github.com/fkie/multimaster_fkie</url>
 
   <buildtool_depend>catkin</buildtool_depend>
+  <buildtool_depend condition="$ROS_PYTHON_VERSION == 2">python-setuptools</buildtool_depend>
+  <buildtool_depend condition="$ROS_PYTHON_VERSION == 3">python3-setuptools</buildtool_depend>
+
   <build_depend>diagnostic_msgs</build_depend>
   <build_depend>fkie_multimaster_msgs</build_depend>
   <build_depend condition="$ROS_PYTHON_VERSION == 2">python-catkin-pkg</build_depend>

--- a/fkie_node_manager_daemon/setup.py
+++ b/fkie_node_manager_daemon/setup.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-from distutils.core import setup
+from setuptools import setup
 from catkin_pkg.python_setup import generate_distutils_setup
 
 d = generate_distutils_setup(


### PR DESCRIPTION
Recently users of newer distributions who build Noetic from source noticed issues when importing setup from distutils.core.
This problem was discussed on [Discourse](https://discourse.ros.org/t/ros-1-and-python-3-10s-deprecation-of-distutils-core/29834), and we hope that we can make the needed updates to Noetic to allow for future builds from source of Noetic.
As a first step, this PR introduces changes from the [Noetic Migration Guide](https://wiki.ros.org/noetic/Migration#Setuptools_instead_of_Distutils) that addresses the change to the setuptools module instead of distutils.core and the corresponding buildtool_depend tags for python 2&3.